### PR TITLE
feat: Package helm charts with app version

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ async function prepare(pluginConfig, context) {
         await verifyChart(pluginConfig, context);
     }
 
-    hasChartChanges = await prepareChart(pluginConfig, context);
+    await prepareChart(pluginConfig, context);
     prepared = true;
 }
 
@@ -29,9 +29,7 @@ async function publish(pluginConfig, context) {
         await prepareChart(pluginConfig, context);
     }
 
-    if (hasChartChanges) {
-        await publishChart(pluginConfig, context);
-    }
+    await publishChart(pluginConfig, context);
 }
 
 module.exports = { verifyConditions, prepare, publish };

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -2,7 +2,6 @@ const fsPromises = require('fs').promises;
 const path = require('path');
 const yaml = require('js-yaml');
 const semver = require('semver');
-const execa = require('execa');
 const utils = require('./utils');
 
 module.exports = async (pluginConfig, context) => {
@@ -10,27 +9,16 @@ module.exports = async (pluginConfig, context) => {
 
     const appVersion = context.nextRelease.version;
 
-    const lastReleaseGitTag = context.lastRelease.gitTag;
     const chartPath = pluginConfig.chartPath;
-    const filePath = path.join(pluginConfig.chartPath, 'Chart.yaml');
+    const filePath = path.join(chartPath, 'Chart.yaml');
 
     const chartYaml = await fsPromises.readFile(filePath);
     const oldChart = yaml.load(chartYaml);
 
-    const version = semver.inc(oldChart.version, context.nextRelease.type);
-
-    const modifiedFiles = await utils.gitGetModifiedFilesSince(lastReleaseGitTag, 'HEAD', logger);
-
-    const hasChartChanges = shouldUpdateChartVersion(modifiedFiles, chartPath);
-    const hasCodeChanges = shouldUpdateAppVersion(modifiedFiles, chartPath);
-
-    const changes = {};
-    if (hasChartChanges) {
-        changes.version = version
-    } 
-    if (hasCodeChanges) {
-        changes.appVersion = appVersion
-    } 
+    const changes = {
+        version: appVersion,
+        appVersion: appVersion
+    };
 
     const newChart = yaml.dump({ ...oldChart, ...changes });
     const changesString = Object.entries(changes).map(([key, value]) => `${key}: ${value}`).join(', ') || 'no changes'
@@ -39,7 +27,7 @@ module.exports = async (pluginConfig, context) => {
 
     await fsPromises.writeFile(filePath, newChart);
 
-    return hasChartChanges
+    return true
 };
 
 const shouldUpdateChartVersion = (modifiedFiles, chartPath) => modifiedFiles.some(file => file.includes(chartPath))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-release-helm-app",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-release-helm-app",
-  "version": "3.0.6",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-release-helm-app",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "semantic-release plugin to update version and appVersion in a Helm chart",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-release-helm-app",
-  "version": "3.0.6",
+  "version": "4.0.0",
   "description": "semantic-release plugin to update version and appVersion in a Helm chart",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
BREAKING CHANGE: The version of chart is mapped to version of the application and includes an `appVersion` to represent version of tag being released