### PR TITLE
fix: Fix app version lacking behind

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -28,10 +28,7 @@ module.exports = async (pluginConfig, context) => {
     if (hasChartChanges) {
         changes.version = version
     } 
-    if (hasCodeChanges) {
-        changes.appVersion = appVersion
-    } 
-
+    changes.appVersion = appVersion
     const newChart = yaml.dump({ ...oldChart, ...changes });
     const changesString = Object.entries(changes).map(([key, value]) => `${key}: ${value}`).join(', ') || 'no changes'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-release-helm-app",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-release-helm-app",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "semantic-release plugin to update version and appVersion in a Helm chart",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
to fix an issue raised by @SalmaZed 
> in [this semantic commit for example](https://github.com/swvl/api/commit/74bc6b0fbe17553caf64129f8e0efeddcccb7833), only the version changed, not the appVersion, probably bec it followed [the change done by this PR](https://github.com/swvl/api/commit/2be6258f5bfa5569a12f19f116632f05f56c17ce) which was a change in the helm chart

This causes checking out tag `v1.2.3` and running helm upgrade will deploy `v1.2.2`. Although this might not be a problem generally, in this example mentioned by salma it's a very big problem because it skipped the previous hotfix as it wasn't released properly. Also, this can cause confusion